### PR TITLE
fix: added kp endpoints in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You need the following permissions to run this module.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_existing_key_ring_keys"></a> [existing\_key\_ring\_keys](#module\_existing\_key\_ring\_keys) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key.git | v1.2.1 |
-| <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git | v2.4.1 |
+| <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git | v2.5.0 |
 | <a name="module_key_protect_key_rings"></a> [key\_protect\_key\_rings](#module\_key\_protect\_key\_rings) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring.git | v2.3.1 |
 | <a name="module_key_protect_keys"></a> [key\_protect\_keys](#module\_key\_protect\_keys) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key.git | v1.2.1 |
 
@@ -147,6 +147,8 @@ No resources.
 | <a name="output_key_protect_name"></a> [key\_protect\_name](#output\_key\_protect\_name) | Key Protect Name |
 | <a name="output_key_rings"></a> [key\_rings](#output\_key\_rings) | IDs of new Key Rings created by the module |
 | <a name="output_keys"></a> [keys](#output\_keys) | IDs of new Keys created by the module |
+| <a name="output_kp_private_endpoint"></a> [kp\_private\_endpoint](#output\_kp\_private\_endpoint) | Instance private endpoint URL |
+| <a name="output_kp_public_endpoint"></a> [kp\_public\_endpoint](#output\_kp\_public\_endpoint) | Instance public endpoint URL |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 <!-- BEGIN CONTRIBUTING HOOK -->
 

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -41,3 +41,13 @@ output "existing_key_ring_keys" {
   description = "Keys created by the module in existing Key Rings"
   value       = module.key_protect_all_inclusive.existing_key_ring_keys
 }
+
+output "kp_private_endpoint" {
+  description = "Instance private endpoint URL"
+  value       = module.key_protect_all_inclusive.kp_private_endpoint
+}
+
+output "kp_public_endpoint" {
+  description = "Instance public endpoint URL"
+  value       = module.key_protect_all_inclusive.kp_public_endpoint
+}

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ locals {
 
 module "key_protect" {
   count                             = var.create_key_protect_instance ? 1 : 0
-  source                            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v2.4.1"
+  source                            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v2.5.0"
   key_protect_name                  = var.key_protect_instance_name
   region                            = var.region
   service_endpoints                 = var.key_protect_endpoint_type

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,3 +36,13 @@ output "existing_key_ring_keys" {
   description = "IDs of Keys created by the module in existing Key Rings"
   value       = module.existing_key_ring_keys
 }
+
+output "kp_private_endpoint" {
+  description = "Instance private endpoint URL"
+  value       = [for kp in module.key_protect : kp.kp_private_endpoint][0]
+}
+
+output "kp_public_endpoint" {
+  description = "Instance public endpoint URL"
+  value       = [for kp in module.key_protect : kp.kp_public_endpoint][0]
+}


### PR DESCRIPTION
### Description

Added kp endpoints in output.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
