### PR TITLE
feat: added endpoint output when existing instance is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ For more info, see [Understanding user roles and resources](https://cloud.ibm.co
 | <a name="output_key_rings"></a> [key\_rings](#output\_key\_rings) | IDs of new Key Rings created by the module |
 | <a name="output_keys"></a> [keys](#output\_keys) | IDs of new Keys created by the module |
 | <a name="output_kms_guid"></a> [kms\_guid](#output\_kms\_guid) | KMS GUID |
-| <a name="output_kp_private_endpoint"></a> [kp\_private\_endpoint](#output\_kp\_private\_endpoint) | Key Protect instance private endpoint URL |
-| <a name="output_kp_public_endpoint"></a> [kp\_public\_endpoint](#output\_kp\_public\_endpoint) | Key Protect instance public endpoint URL |
+| <a name="output_kms_private_endpoint"></a> [kms\_private\_endpoint](#output\_kms\_private\_endpoint) | Key Management Service instance private endpoint URL |
+| <a name="output_kms_public_endpoint"></a> [kms\_public\_endpoint](#output\_kms\_public\_endpoint) | Key Management Service instance public endpoint URL |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 <!-- Leave this section as is so that your module has a link to local development environment set up steps for contributors to follow -->

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ For more info, see [Understanding user roles and resources](https://cloud.ibm.co
 
 ### Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [ibm_resource_instance.existing_kms_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/resource_instance) | data source |
 
 ### Inputs
 

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -37,12 +37,12 @@ output "keys" {
   value       = module.key_protect_all_inclusive.keys
 }
 
-output "kp_private_endpoint" {
+output "kms_private_endpoint" {
   description = "Instance private endpoint URL"
-  value       = module.key_protect_all_inclusive.kp_private_endpoint
+  value       = module.key_protect_all_inclusive.kms_private_endpoint
 }
 
-output "kp_public_endpoint" {
+output "kms_public_endpoint" {
   description = "Instance public endpoint URL"
-  value       = module.key_protect_all_inclusive.kp_public_endpoint
+  value       = module.key_protect_all_inclusive.kms_public_endpoint
 }

--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,8 @@ data "ibm_resource_instance" "existing_kms_instance" {
 }
 
 locals {
-  kms_public_endpoint  = var.create_key_protect_instance ? module.key_protect.kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
-  kms_private_endpoint = var.create_key_protect_instance ? module.key_protect.kp_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
+  kms_public_endpoint  = var.create_key_protect_instance ? module.key_protect[0].kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
+  kms_private_endpoint = var.create_key_protect_instance ? module.key_protect[0].kp_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
 }
 
 module "key_protect" {

--- a/main.tf
+++ b/main.tf
@@ -30,13 +30,13 @@ locals {
 ##############################################################################
 
 data "ibm_resource_instance" "existing_kms_instance" {
-  count      = var.existing_kms_instance_guid != null ? 1 : 0
+  count      = var.create_key_protect_instance ? 0 : 1
   identifier = var.existing_kms_instance_guid
 }
 
 locals {
-  kms_public_endpoint  = var.create_key_protect_instance ? module.key_protect[0].kms_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
-  kms_private_endpoint = var.create_key_protect_instance ? module.key_protect[0].kms_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
+  kms_public_endpoint  = var.create_key_protect_instance ? module.key_protect[0].kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
+  kms_private_endpoint = var.create_key_protect_instance ? module.key_protect[0].kp_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
 }
 
 module "key_protect" {

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,16 @@ locals {
 # Key Protect Instance
 ##############################################################################
 
+data "ibm_resource_instance" "existing_kms_instance" {
+  count      = var.existing_kms_instance_guid != null ? 1 : 0
+  identifier = var.existing_kms_instance_guid
+}
+
+locals {
+  kms_public_endpoint  = var.create_key_protect_instance ? module.key_protect.kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
+  kms_private_endpoint = var.create_key_protect_instance ? module.key_protect.kp_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
+}
+
 module "key_protect" {
   count                             = var.create_key_protect_instance ? 1 : 0
   source                            = "terraform-ibm-modules/key-protect/ibm"

--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,8 @@ data "ibm_resource_instance" "existing_kms_instance" {
 }
 
 locals {
-  kms_public_endpoint  = var.create_key_protect_instance ? module.key_protect[0].kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
-  kms_private_endpoint = var.create_key_protect_instance ? module.key_protect[0].kp_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
+  kms_public_endpoint  = var.create_key_protect_instance ? module.key_protect[0].kms_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
+  kms_private_endpoint = var.create_key_protect_instance ? module.key_protect[0].kms_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
 }
 
 module "key_protect" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,12 +37,12 @@ output "keys" {
   value       = merge(module.kms_keys, module.existing_key_ring_keys)
 }
 
-output "kp_private_endpoint" {
-  description = "Key Protect instance private endpoint URL"
+output "kms_private_endpoint" {
+  description = "Key Management Service instance private endpoint URL"
   value       = local.kms_private_endpoint
 }
 
-output "kp_public_endpoint" {
-  description = "Key Protect instance public endpoint URL"
+output "kms_public_endpoint" {
+  description = "Key Management Service instance public endpoint URL"
   value       = local.kms_public_endpoint
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,10 +39,10 @@ output "keys" {
 
 output "kp_private_endpoint" {
   description = "Key Protect instance private endpoint URL"
-  value       = var.create_key_protect_instance ? module.key_protect[0].kp_private_endpoint : null
+  value       = local.kms_private_endpoint
 }
 
 output "kp_public_endpoint" {
   description = "Key Protect instance public endpoint URL"
-  value       = var.create_key_protect_instance ? module.key_protect[0].kp_public_endpoint : null
+  value       = local.kms_public_endpoint
 }

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -18,6 +18,14 @@ locals {
   existing_kms_guid                = length(local.parsed_existing_kms_instance_crn) > 0 ? local.parsed_existing_kms_instance_crn[7] : null
   kp_endpoint_type                 = var.key_protect_allowed_network == "private-only" ? "private" : "public"
   kms_endpoint_type                = var.existing_kms_instance_crn != null ? var.kms_endpoint_type : local.kp_endpoint_type
+
+  kms_public_endpoint  = var.existing_kms_instance_crn == null ?  module.kms.kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
+  kms_private_endpoint = var.existing_kms_instance_crn == null ? module.kms.kp_private_endpoint: data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
+}
+
+data "ibm_resource_instance" "existing_kms_instance" {
+  count      = var.existing_kms_instance_crn != null ? 1 : 0
+  identifier = local.existing_kms_guid
 }
 
 module "kms" {

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -19,8 +19,8 @@ locals {
   kp_endpoint_type                 = var.key_protect_allowed_network == "private-only" ? "private" : "public"
   kms_endpoint_type                = var.existing_kms_instance_crn != null ? var.kms_endpoint_type : local.kp_endpoint_type
 
-  kms_public_endpoint  = var.existing_kms_instance_crn == null ?  module.kms.kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
-  kms_private_endpoint = var.existing_kms_instance_crn == null ? module.kms.kp_private_endpoint: data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
+  kms_public_endpoint  = var.existing_kms_instance_crn == null ? module.kms.kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
+  kms_private_endpoint = var.existing_kms_instance_crn == null ? module.kms.kp_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
 }
 
 data "ibm_resource_instance" "existing_kms_instance" {

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -18,14 +18,6 @@ locals {
   existing_kms_guid                = length(local.parsed_existing_kms_instance_crn) > 0 ? local.parsed_existing_kms_instance_crn[7] : null
   kp_endpoint_type                 = var.key_protect_allowed_network == "private-only" ? "private" : "public"
   kms_endpoint_type                = var.existing_kms_instance_crn != null ? var.kms_endpoint_type : local.kp_endpoint_type
-
-  kms_public_endpoint  = var.existing_kms_instance_crn == null ? module.kms.kp_public_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.public"]
-  kms_private_endpoint = var.existing_kms_instance_crn == null ? module.kms.kp_private_endpoint : data.ibm_resource_instance.existing_kms_instance[0].extensions["endpoints.private"]
-}
-
-data "ibm_resource_instance" "existing_kms_instance" {
-  count      = var.existing_kms_instance_crn != null ? 1 : 0
-  identifier = local.existing_kms_guid
 }
 
 module "kms" {

--- a/solutions/standard/outputs.tf
+++ b/solutions/standard/outputs.tf
@@ -48,10 +48,10 @@ output "keys" {
 
 output "kp_private_endpoint" {
   description = "Key Protect instance private endpoint URL."
-  value       = local.kms_private_endpoint
+  value       = module.kms.kp_private_endpoint
 }
 
 output "kp_public_endpoint" {
   description = "Key Protect instance public endpoint URL."
-  value       = local.kms_public_endpoint
+  value       = module.kms.kp_public_endpoint
 }

--- a/solutions/standard/outputs.tf
+++ b/solutions/standard/outputs.tf
@@ -48,10 +48,10 @@ output "keys" {
 
 output "kms_private_endpoint" {
   description = "Key Management Service instance private endpoint URL."
-  value       = module.kms.kp_private_endpoint
+  value       = module.kms.kms_private_endpoint
 }
 
 output "kms_public_endpoint" {
   description = "Key Management Service instance public endpoint URL."
-  value       = module.kms.kp_public_endpoint
+  value       = module.kms.kms_public_endpoint
 }

--- a/solutions/standard/outputs.tf
+++ b/solutions/standard/outputs.tf
@@ -47,11 +47,11 @@ output "keys" {
 }
 
 output "kp_private_endpoint" {
-  description = "Key Protect instance private endpoint URL when an instance is created, otherwise null"
-  value       = module.kms.kp_private_endpoint
+  description = "Key Protect instance private endpoint URL."
+  value       = local.kms_private_endpoint
 }
 
 output "kp_public_endpoint" {
-  description = "Key Protect instance public endpoint URL when an instance is created, otherwise null"
-  value       = module.kms.kp_public_endpoint
+  description = "Key Protect instance public endpoint URL."
+  value       = local.kms_public_endpoint
 }

--- a/solutions/standard/outputs.tf
+++ b/solutions/standard/outputs.tf
@@ -46,12 +46,12 @@ output "keys" {
   value       = module.kms.keys
 }
 
-output "kp_private_endpoint" {
-  description = "Key Protect instance private endpoint URL."
+output "kms_private_endpoint" {
+  description = "Key Management Service instance private endpoint URL."
   value       = module.kms.kp_private_endpoint
 }
 
-output "kp_public_endpoint" {
-  description = "Key Protect instance public endpoint URL."
+output "kms_public_endpoint" {
+  description = "Key Management Service instance public endpoint URL."
   value       = module.kms.kp_public_endpoint
 }


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-kms-all-inclusive/issues/506

- added kms endpoint output when existing instance is used
- Renamed `kp_public_endpoint` to `kms_public_endpoint` and  `kp_private_endpoint` to `kms_private_endpoint` in solutions/standard and main module output

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- added kms endpoint output when existing instance is used
- Renamed `kp_public_endpoint` to `kms_public_endpoint` and  `kp_private_endpoint` to `kms_private_endpoint` in solutions/standard and main module output

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
