### PR TITLE
fix: remove the deprecated force delete key ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ module "kms_all_inclusive" {
     {
       key_ring_name = "example-key-ring-1"
       existing_key_ring = true
-      force_delete_key_ring = false
       keys = [
         {
           key_name = "example-key-1"
@@ -101,7 +100,6 @@ module "kms_all_inclusive" {
     {
       key_ring_name = "example-key-ring-2"
       existing_key_ring = false
-      force_delete_key_ring = true
       keys = [
         {
           key_name = "example-key-3"
@@ -143,7 +141,7 @@ For more info, see [Understanding user roles and resources](https://cloud.ibm.co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.65.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.69.0, <2.0.0 |
 
 ### Modules
 
@@ -152,7 +150,7 @@ For more info, see [Understanding user roles and resources](https://cloud.ibm.co
 | <a name="module_cbr_rule"></a> [cbr\_rule](#module\_cbr\_rule) | terraform-ibm-modules/cbr/ibm//modules/cbr-rule-module | 1.27.0 |
 | <a name="module_existing_key_ring_keys"></a> [existing\_key\_ring\_keys](#module\_existing\_key\_ring\_keys) | terraform-ibm-modules/kms-key/ibm | v1.2.4 |
 | <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | terraform-ibm-modules/key-protect/ibm | 2.8.5 |
-| <a name="module_kms_key_rings"></a> [kms\_key\_rings](#module\_kms\_key\_rings) | terraform-ibm-modules/kms-key-ring/ibm | v2.4.1 |
+| <a name="module_kms_key_rings"></a> [kms\_key\_rings](#module\_kms\_key\_rings) | terraform-ibm-modules/kms-key-ring/ibm | v2.5.0 |
 | <a name="module_kms_keys"></a> [kms\_keys](#module\_kms\_keys) | terraform-ibm-modules/kms-key/ibm | v1.2.4 |
 
 ### Resources
@@ -178,7 +176,7 @@ For more info, see [Understanding user roles and resources](https://cloud.ibm.co
 | <a name="input_key_protect_instance_name"></a> [key\_protect\_instance\_name](#input\_key\_protect\_instance\_name) | The name to give the Key Protect instance that will be provisioned by this module. Only used if 'create\_key\_protect\_instance' is true. | `string` | `"key-protect"` | no |
 | <a name="input_key_protect_plan"></a> [key\_protect\_plan](#input\_key\_protect\_plan) | Plan for the Key Protect instance. Currently only 'tiered-pricing' is supported. Only used if 'create\_key\_protect\_instance' is true. | `string` | `"tiered-pricing"` | no |
 | <a name="input_key_ring_endpoint_type"></a> [key\_ring\_endpoint\_type](#input\_key\_ring\_endpoint\_type) | The type of endpoint to be used for creating key rings. Accepts 'public' or 'private' | `string` | `"public"` | no |
-| <a name="input_keys"></a> [keys](#input\_keys) | A list of objects which contain the key ring name, a flag indicating if this key ring already exists, and a flag to enable force deletion of the key ring. In addition, this object contains a list of keys with all of the information on the keys to be created in that key ring. | <pre>list(object({<br/>    key_ring_name         = string<br/>    existing_key_ring     = optional(bool, false)<br/>    force_delete_key_ring = optional(bool, false)<br/>    keys = list(object({<br/>      key_name                 = string<br/>      standard_key             = optional(bool, false)<br/>      rotation_interval_month  = optional(number, 1)<br/>      dual_auth_delete_enabled = optional(bool, false)<br/>      force_delete             = optional(bool, false)<br/>    }))<br/>  }))</pre> | `[]` | no |
+| <a name="input_keys"></a> [keys](#input\_keys) | A list of objects which contain the key ring name, a flag indicating if this key ring already exists, and a flag to enable force deletion of the key ring. In addition, this object contains a list of keys with all of the information on the keys to be created in that key ring. | <pre>list(object({<br/>    key_ring_name     = string<br/>    existing_key_ring = optional(bool, false)<br/>    keys = list(object({<br/>      key_name                 = string<br/>      standard_key             = optional(bool, false)<br/>      rotation_interval_month  = optional(number, 1)<br/>      dual_auth_delete_enabled = optional(bool, false)<br/>      force_delete             = optional(bool, false)<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | The IBM Cloud region where all resources will be provisioned. | `string` | n/a | yes |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The ID of the Resource Group to provision the Key Protect instance in. Not required if 'create\_key\_protect\_instance' is false. | `string` | `null` | no |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Optional list of tags to be added to the Key Protect instance. Only used if 'create\_key\_protect\_instance' is true. | `list(string)` | `[]` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -24,8 +24,7 @@ module "key_protect_all_inclusive" {
   keys = [
     # Create one new Key Ring with multiple new Keys in it
     {
-      key_ring_name         = "${var.prefix}-slz-ring"
-      force_delete_key_ring = true # Setting it to true for testing purpose
+      key_ring_name = "${var.prefix}-slz-ring"
       keys = [
         {
           key_name     = "${var.prefix}-slz-key"

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.65.0"
+      version = "1.69.0"
     }
   }
 }

--- a/examples/existing-resources/main.tf
+++ b/examples/existing-resources/main.tf
@@ -9,9 +9,8 @@ module "key_protect_all_inclusive" {
   existing_kms_instance_crn   = var.existing_kms_instance_crn
   keys = [
     {
-      key_ring_name         = "default"
-      existing_key_ring     = true
-      force_delete_key_ring = true # Setting it to true for testing purpose
+      key_ring_name     = "default"
+      existing_key_ring = true
       keys = [
         {
           key_name     = "test-key"

--- a/examples/existing-resources/version.tf
+++ b/examples/existing-resources/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.65.0"
+      version = ">= 1.69.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -75,19 +75,17 @@ locals {
     for key_ring in var.keys :
     key_ring.existing_key_ring ? [] : [{
       key_ring_name = key_ring.key_ring_name
-      force_delete  = key_ring.force_delete_key_ring
     }]
   ])
 }
 
 module "kms_key_rings" {
   source        = "terraform-ibm-modules/kms-key-ring/ibm"
-  version       = "v2.4.1"
+  version       = "v2.5.0"
   for_each      = { for obj in local.key_rings : obj.key_ring_name => obj }
   instance_id   = local.kms_guid
   endpoint_type = var.key_ring_endpoint_type
   key_ring_id   = each.value.key_ring_name
-  force_delete  = each.value.force_delete
 }
 
 moved {

--- a/solutions/standard/DA-keys.md
+++ b/solutions/standard/DA-keys.md
@@ -12,7 +12,6 @@ To enter a custom value, use the edit action to open the "Edit Array" panel. Add
 
 - `key_ring_name` (required): A unique human-readable name that identifies this key ring. To protect your privacy, do not use personal data, such as your name or location. The key ring name can be between 2 and 100 characters.
 - `existing_key_ring` (optional, default = `false`): Set to true if the key ring already exists and keys should be added to it.
-- `force_delete_key_ring` (optional, default = `true`): Whether to force delete the key ring with a destroy command or when the projects configuration is removed. When `true` this force deletes the key ring in the event that it contains keys in the `Destroyed` state, see [Deleting key rings](https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys&interface=api#delete-key-ring-api).
 
 ### Key options
 
@@ -28,7 +27,6 @@ The following example includes all the configuration options for two key rings. 
       {
         "key_ring_name": "da-ring-1",
         "existing_key_ring": false,
-        "force_delete_key_ring": true,
         "keys": [
           {
             "key_name": "da-key-1-1",
@@ -49,7 +47,6 @@ The following example includes all the configuration options for two key rings. 
       {
         "key_ring_name": "da-ring-2",
         "existing_key_ring": false,
-        "force_delete_key_ring": true,
         "keys": [
           {
             "key_name": "da-key-2-1",

--- a/solutions/standard/DA-keys.md
+++ b/solutions/standard/DA-keys.md
@@ -2,7 +2,7 @@
 
 When you add a key management service from the IBM Cloud catalog to an IBM Cloud Projects service, you can configure key rings and keys. In the edit mode for the projects configuration, select the Configure panel and then click the optional tab.
 
-In the configuration, specify the name of the key ring, whether the key ring exists, and whether to force the deletion of the key. The object also contains a list of keys with all the information about the keys that you want to create in that key ring.
+In the configuration, specify the name of the key ring and whether the key ring exists. The object also contains a list of keys with all the information about the keys that you want to create in that key ring.
 
 To enter a custom value, use the edit action to open the "Edit Array" panel. Add the KMS key ring and key configurations to the array here.
 

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -92,9 +92,8 @@ variable "kms_endpoint_type" {
 
 variable "keys" {
   type = list(object({
-    key_ring_name         = string
-    existing_key_ring     = optional(bool, false)
-    force_delete_key_ring = optional(bool, true)
+    key_ring_name     = string
+    existing_key_ring = optional(bool, false)
     keys = list(object({
       key_name                 = string
       standard_key             = optional(bool, false)

--- a/variables.tf
+++ b/variables.tf
@@ -96,9 +96,8 @@ variable "existing_kms_instance_crn" {
 
 variable "keys" {
   type = list(object({
-    key_ring_name         = string
-    existing_key_ring     = optional(bool, false)
-    force_delete_key_ring = optional(bool, false)
+    key_ring_name     = string
+    existing_key_ring = optional(bool, false)
     keys = list(object({
       key_name                 = string
       standard_key             = optional(bool, false)

--- a/version.tf
+++ b/version.tf
@@ -7,7 +7,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.65.0, <2.0.0"
+      version = ">= 1.69.0, <2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

The force_delete flag has now been deprecated by the provider, removing from the module.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

remove the force_delete variable as this feature has been deprecated

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
