### PR TITLE
fix: removed CBR rule added twice in root module

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ For more info, see [Understanding user roles and resources](https://cloud.ibm.co
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cbr_rule"></a> [cbr\_rule](#module\_cbr\_rule) | terraform-ibm-modules/cbr/ibm//modules/cbr-rule-module | 1.29.0 |
 | <a name="module_existing_key_ring_keys"></a> [existing\_key\_ring\_keys](#module\_existing\_key\_ring\_keys) | terraform-ibm-modules/kms-key/ibm | v1.2.4 |
 | <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | terraform-ibm-modules/key-protect/ibm | 2.9.0 |
 | <a name="module_kms_key_rings"></a> [kms\_key\_rings](#module\_kms\_key\_rings) | terraform-ibm-modules/kms-key-ring/ibm | v2.5.0 |

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ module "key_protect" {
   dual_auth_delete_enabled          = var.dual_auth_delete_enabled
   key_create_import_access_enabled  = var.key_create_import_access_enabled
   key_create_import_access_settings = var.key_create_import_access_settings
+  cbr_rules                         = var.cbr_rules
 }
 
 ##############################################################################
@@ -158,42 +159,7 @@ module "existing_key_ring_keys" {
 # Context Based Restrictions
 ##############################################################################
 
-locals {
-  default_operations = [{
-    api_types = [
-      {
-        "api_type_id" : "crn:v1:bluemix:public:context-based-restrictions::::api-type:"
-      },
-      {
-        "api_type_id" : "crn:v1:bluemix:public:context-based-restrictions::::platform-api-type:"
-      }
-    ]
-  }]
-}
-
-module "cbr_rule" {
-  count            = length(var.cbr_rules)
-  source           = "terraform-ibm-modules/cbr/ibm//modules/cbr-rule-module"
-  version          = "1.29.0"
-  rule_description = var.cbr_rules[count.index].description
-  enforcement_mode = var.cbr_rules[count.index].enforcement_mode
-  rule_contexts    = var.cbr_rules[count.index].rule_contexts
-  resources = [{
-    attributes = [
-      {
-        name  = "accountId"
-        value = var.cbr_rules[count.index].account_id
-      },
-      {
-        name     = "serviceInstance"
-        value    = local.kms_guid
-        operator = "stringEquals"
-      },
-      {
-        name  = "serviceName"
-        value = "kms"
-      }
-    ]
-  }]
-  operations = var.cbr_rules[count.index].operations == null ? local.default_operations : var.cbr_rules[count.index].operations
+moved {
+  from = module.cbr_rule
+  to   = module.key_protect[0].module.cbr_rule
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,5 +54,5 @@ output "kms_public_endpoint" {
 
 output "cbr_rule_ids" {
   description = "CBR rule ids created to restrict Key Protect"
-  value       = length(module.cbr_rule[*]) > 0 ? module.cbr_rule[*].rule_id : null
+  value       = length(module.key_protect[*]) > 0 ? module.key_protect[0].cbr_rule_ids : null
 }


### PR DESCRIPTION
### Description

Removed CBR rule added twice in root module

[GIT issue](https://github.ibm.com/GoldenEye/issues/issues/11897)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

removes CBR rule added twice in root module

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
