### PR TITLE
Revert "fix: updated the DA to use region widget"

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -83,6 +83,56 @@
               "key": "ibmcloud_api_key"
             },
             {
+              "key": "region",
+              "required": true,
+              "options": [
+                {
+                  "displayname": "Dallas (us-south)",
+                  "value": "us-south"
+                },
+                {
+                  "displayname": "Frankfurt (eu-de)",
+                  "value": "eu-de"
+                },
+                {
+                  "displayname": "London (eu-gb)",
+                  "value": "eu-gb"
+                },
+                {
+                  "displayname": "Madrid (eu-es)",
+                  "value": "eu-es"
+                },
+                {
+                  "displayname": "Osaka (jp-osa)",
+                  "value": "jp-osa"
+                },
+                {
+                  "displayname": "Sao Paulo (br-sao)",
+                  "value": "br-sao"
+                },
+                {
+                  "displayname": "Sydney (au-syd)",
+                  "value": "au-syd"
+                },
+                {
+                  "displayname": "Tokyo (jp-tok)",
+                  "value": "jp-tok"
+                },
+                {
+                  "displayname": "Montreal (ca-mon)",
+                  "value": "ca-mon"
+                },
+                {
+                  "displayname": "Toronto (ca-tor)",
+                  "value": "ca-tor"
+                },
+                {
+                  "displayname": "Washington (us-east)",
+                  "value": "us-east"
+                }
+              ]
+            },
+            {
               "key": "prefix",
               "required": true,
               "default_value": "dev",
@@ -98,30 +148,15 @@
               ]
             },
             {
-              "key": "region",
-              "required": true,
-              "custom_config": {
-                "type": "region",
-                "grouping": "deployment",
-                "original_grouping": "deployment",
-                "config_constraints": {
-                  "filterString": "service:kms",
-                  "showKinds": [
-                    "region"
-                  ]
-                }
-              }
-            },
-            {
               "key": "key_protect_plan",
               "required": true,
               "options": [
                 {
-                  "displayname": "Standard",
+                  "displayname": "Tiered Pricing",
                   "value": "tiered-pricing"
                 },
                 {
-                  "displayname": "Cross-region Resiliency",
+                  "displayname": "Cross Region Resiliency",
                   "value": "cross-region-resiliency"
                 }
               ]
@@ -302,6 +337,56 @@
               "key": "ibmcloud_api_key"
             },
             {
+              "key": "region",
+              "required": true,
+              "options": [
+                {
+                  "displayname": "Dallas (us-south)",
+                  "value": "us-south"
+                },
+                {
+                  "displayname": "Frankfurt (eu-de)",
+                  "value": "eu-de"
+                },
+                {
+                  "displayname": "London (eu-gb)",
+                  "value": "eu-gb"
+                },
+                {
+                  "displayname": "Madrid (eu-es)",
+                  "value": "eu-es"
+                },
+                {
+                  "displayname": "Osaka (jp-osa)",
+                  "value": "jp-osa"
+                },
+                {
+                  "displayname": "Sao Paulo (br-sao)",
+                  "value": "br-sao"
+                },
+                {
+                  "displayname": "Sydney (au-syd)",
+                  "value": "au-syd"
+                },
+                {
+                  "displayname": "Tokyo (jp-tok)",
+                  "value": "jp-tok"
+                },
+                {
+                  "displayname": "Montreal (ca-mon)",
+                  "value": "ca-mon"
+                },
+                {
+                  "displayname": "Toronto (ca-tor)",
+                  "value": "ca-tor"
+                },
+                {
+                  "displayname": "Washington (us-east)",
+                  "value": "us-east"
+                }
+              ]
+            },
+            {
               "key": "prefix",
               "required": true,
               "random_string": {
@@ -316,30 +401,15 @@
               ]
             },
             {
-              "key": "region",
-              "required": true,
-              "custom_config": {
-                "type": "region",
-                "grouping": "deployment",
-                "original_grouping": "deployment",
-                "config_constraints": {
-                  "filterString": "service:kms",
-                  "showKinds": [
-                    "region"
-                  ]
-                }
-              }
-            },
-            {
               "key": "key_protect_plan",
               "required": true,
               "options": [
                 {
-                  "displayname": "Standard",
+                  "displayname": "Tiered Pricing",
                   "value": "tiered-pricing"
                 },
                 {
-                  "displayname": "Cross-region Resiliency",
+                  "displayname": "Cross Region Resiliency",
                   "value": "cross-region-resiliency"
                 }
               ]


### PR DESCRIPTION
Reverts terraform-ibm-modules/terraform-ibm-kms-all-inclusive#805

This change fails catalog validation:
```
3 Dec, 09:17:38 Starting version validation..
3 Dec, 09:17:39 Validating installation of Cloud automation for Key Protect...
3 Dec, 09:17:41 FAILED
3 Dec, 09:17:41 Error response from server. Status code: 400; message: {"message":"{\"requestid\":\"584b9b18-6758-4144-a495-e8ffa56f432a\",\"timestamp\":\"2025-12-03T09:17:41.026696663Z\",\"messageid\":\"M1037\",\"message\":\"Invalid Request. [\\\"us-south\\\" is not a valid \\\"region\\\" configuration variable for this account.\\n].\",\"statuscode\":400}","code":400,"global_transaction_id":"ff1d276c-8023-4752-89b1-e22982cad488"}
3 Dec, 09:17:41 
```